### PR TITLE
Remove redundant operations from PathCost private constructor.

### DIFF
--- a/include/central64/grid/PathCost.hpp
+++ b/include/central64/grid/PathCost.hpp
@@ -62,10 +62,9 @@ constexpr PathCost::PathCost(double distance)
 }
 
 constexpr PathCost::PathCost(int64_t multiplier, int)
-    : multiplier_{ (multiplier >= 0) ? (multiplier >= max)  ? max :
-                                                              int64_t(multiplier + 0.5) :
-                                       (multiplier <= -max) ? -max :
-                                                              -int64_t(-multiplier + 0.5) }
+    : multiplier_{ (multiplier >= max)  ? max :
+                   (multiplier <= -max) ? -max :
+                                          multiplier }
 {
 }
 


### PR DESCRIPTION
If there is a reason for that cast to double and truncation, I would be really glad to know. 🙂